### PR TITLE
Add EV0L token contracts and minting scripts

### DIFF
--- a/contracts/BLEUToken.sol
+++ b/contracts/BLEUToken.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract BLEUToken is ERC20, Ownable {
+    constructor() ERC20("BLEU Utility", "BLEU") {}
+    function mint(address to, uint256 amount) external onlyOwner { _mint(to, amount); }
+}

--- a/contracts/EV0L1155.sol
+++ b/contracts/EV0L1155.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract EV0L1155 is ERC1155, Ownable {
+    constructor(string memory baseUri_) ERC1155(baseUri_) {}
+
+    function setURI(string memory newuri) external onlyOwner { _setURI(newuri); }
+
+    function mintAll(address to, uint256[] calldata ids, uint256[] calldata amounts) external onlyOwner {
+        _mintBatch(to, ids, amounts, "");
+    }
+}

--- a/contracts/EV0L721.sol
+++ b/contracts/EV0L721.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+
+contract EV0L721 is ERC721URIStorage, Ownable {
+    uint256 public maxSupply;
+    uint256 public totalMinted;
+
+    constructor(string memory name_, string memory symbol_, uint256 maxSupply_) ERC721(name_, symbol_) {
+        maxSupply = maxSupply_;
+    }
+
+    function safeMint(address to, uint256 tokenId, string memory uri_) public onlyOwner {
+        require(totalMinted < maxSupply, "sold out");
+        _safeMint(to, tokenId);
+        _setTokenURI(tokenId, uri_);
+        unchecked { totalMinted++; }
+    }
+
+    function safeMintBatch(address to, uint256[] calldata tokenIds, string[] calldata uris) external onlyOwner {
+        require(tokenIds.length == uris.length, "len mismatch");
+        require(totalMinted + tokenIds.length <= maxSupply, "exceeds");
+        for (uint256 i = 0; i < tokenIds.length; i++) {
+            _safeMint(to, tokenIds[i]);
+            _setTokenURI(tokenIds[i], uris[i]);
+        }
+        totalMinted += tokenIds.length;
+    }
+}

--- a/contracts/WalletID.sol
+++ b/contracts/WalletID.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract WalletID is ERC721URIStorage, Ownable {
+    constructor() ERC721("WalletID", "WID") {}
+
+    function issue(address to, uint256 tokenId, string memory uri_) external onlyOwner {
+        _safeMint(to, tokenId);
+        _setTokenURI(tokenId, uri_);
+    }
+
+    function _update(address to, uint256 tokenId, address auth) internal override returns (address) {
+        // Disable transfers: only mint (from 0) and burn (to 0) allowed
+        address from = _ownerOf(tokenId);
+        require(from == address(0) || to == address(0), "non-transferable");
+        return super._update(to, tokenId, auth);
+    }
+}

--- a/scripts/mint1155_all.ts
+++ b/scripts/mint1155_all.ts
@@ -1,0 +1,18 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const CONTRACT = "0xYOUR_1155_ADDRESS";
+  const RECIPIENT = "0xYOUR_WALLET";
+
+  // Fill ids and amounts to “all”
+  const ids = [0,1,2,3];         // edit
+  const amounts = ids.map(() => 1); // or set per id
+
+  const t1155 = await ethers.getContractAt("EV0L1155", CONTRACT);
+  const tx = await t1155.mintAll(RECIPIENT, ids, amounts);
+  console.log("tx:", tx.hash);
+  await tx.wait();
+  console.log("done");
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/mint721_from_csv.ts
+++ b/scripts/mint721_from_csv.ts
@@ -1,0 +1,38 @@
+import { ethers } from "hardhat";
+import fs from "fs";
+import path from "path";
+import { parse } from "csv-parse/sync";
+
+type Row = { token_id: string; metadata_cid: string };
+
+async function main() {
+  const CONTRACT = "0xYOUR_721_ADDRESS";
+  const RECIPIENT = "0xYOUR_WALLET";
+
+  const csvPath = path.resolve("nft_storage_upload_template.csv"); // your CSV
+  const rows: Row[] = parse(fs.readFileSync(csvPath), { columns: true, skip_empty_lines: true });
+
+  const ids: bigint[] = [];
+  const uris: string[] = [];
+
+  for (const r of rows) {
+    const id = BigInt(r.token_id.trim());
+    const uri = `ipfs://${r.metadata_cid.trim()}`;
+    ids.push(id);
+    uris.push(uri);
+  }
+
+  const nft = await ethers.getContractAt("EV0L721", CONTRACT);
+  // Mint in chunks to avoid block gas limits
+  const CHUNK = 50;
+  for (let i = 0; i < ids.length; i += CHUNK) {
+    const idsChunk = ids.slice(i, i + CHUNK);
+    const urisChunk = uris.slice(i, i + CHUNK);
+    const tx = await nft.safeMintBatch(RECIPIENT, idsChunk.map(v => Number(v)), urisChunk);
+    console.log("mint chunk tx:", tx.hash);
+    await tx.wait();
+  }
+  console.log("done");
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/nftstorage_upload.ts
+++ b/scripts/nftstorage_upload.ts
@@ -1,0 +1,19 @@
+import fs from "fs";
+import path from "path";
+import { parse } from "csv-parse/sync";
+import { NFTStorage, File } from "nft.storage";
+import mime from "mime";
+
+type Row = { token_id: string; metadata_json_path: string };
+
+async function main() {
+  const client = new NFTStorage({ token: process.env.NFT_STORAGE_KEY! });
+  const rows: Row[] = parse(fs.readFileSync("nft_storage_upload_template.csv"), { columns: true });
+  for (const r of rows) {
+    const filePath = path.resolve(r.metadata_json_path);
+    const cid = await client.storeBlob(new File([fs.readFileSync(filePath)], path.basename(filePath), { type: mime.getType(filePath) || "application/json" }));
+    console.log(`${r.token_id},${cid}`);
+  }
+}
+
+main().catch(console.error);

--- a/scripts/tokenize_wallet.ts
+++ b/scripts/tokenize_wallet.ts
@@ -1,0 +1,21 @@
+import { ethers } from "hardhat";
+
+async function main() {
+  const WALLET = "0xYOUR_WALLET";
+
+  const bleu = await ethers.getContractAt("BLEUToken", "0xYOUR_BLEU20_ADDRESS");
+  const wid  = await ethers.getContractAt("WalletID",  "0xYOUR_WALLETID_ADDRESS");
+
+  const erc20Amount = ethers.parseUnits("1000000000", 18); // edit supply
+  console.log("mint BLEU...");
+  let tx = await bleu.mint(WALLET, erc20Amount); await tx.wait();
+
+  const tokenId = 1; // stable ID per wallet
+  const widURI = "ipfs://YOUR_WALLETID_METADATA"; // optional badge JSON
+  console.log("issue WalletID...");
+  tx = await wid.issue(WALLET, tokenId, widURI); await tx.wait();
+
+  console.log("tokenized");
+}
+
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add ERC-721, ERC-1155, ERC-20, and non-transferable WalletID contracts for the EV0L suite
- provide Hardhat scripts for batch minting tokens and issuing WalletID/utility tokens
- include an NFT.Storage upload helper script for preparing metadata CIDs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e09be611dc8324922c6cea201f623d 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request introduces several new token contracts and accompanying scripts to enhance the EV0L suite. The smart contracts include implementations for ERC20, ERC1155, ERC721, and a unique WalletID contract with non-transferable features. The new scripts automate processes such as batch minting from static data or CSV inputs and handle NFT metadata uploads with NFT.Storage. Together, these changes significantly expand the functionality and streamline token operations in the project.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>