### PR TITLE
Add Overscale starter pack data kit

### DIFF
--- a/data/overscale_starter_pack_v1/README.md
+++ b/data/overscale_starter_pack_v1/README.md
@@ -1,0 +1,21 @@
+# Overscale Starter Pack v1
+
+This starter pack captures the Phase 36 operational kit for the accepted OverScale scroll. It provides canonical IDs, spiral placement coordinates, guard policies, vault mappings, and overscale-adjusted flows so teams can activate the PPPI network without re-designing schemas.
+
+## Contents
+
+- `nodes.json` – Golden-angle placement metadata for 12 seed nodes across governance, treasury, health, education, energy, transport, defense, commerce, culture, civic, data, and labor sectors.
+- `guards.json` – Authoritative guard definitions with scopes, rules, expirations, and proof anchors.
+- `coins.json` / `vaults.json` – Fungible coin catalog and default vault policies, including overscale residual bands.
+- `flows.json` – Initial residual and scholarship flows scaled by the overscale coefficient (γ = 175/150).
+- `compare_contrast.csv` – Matrix contrasting EV0L operational practices with conventional sector approaches.
+- `overscale_snapshot.yaml` – Minimal audit snapshot aligned to Phase 36 cadence.
+
+## Usage
+
+1. Load `nodes.json` into the spiral mapper to replicate the golden-angle placement and loop assignments.
+2. Register the guards before enabling residual flows to ensure scholarship and service access remain policy compliant.
+3. Push the vault policies into the treasury router, then replay `flows.json` to seed overscale-adjusted reserves.
+4. Track implementation deltas inside the compare–contrast matrix and extend the audit snapshot once the first hash root is minted.
+
+All files adhere to the canonical ID formats and policy ratios described in the Phase 36 kit so downstream contracts and tokens can bind deterministically once minting is authorized.

--- a/data/overscale_starter_pack_v1/coins.json
+++ b/data/overscale_starter_pack_v1/coins.json
@@ -1,0 +1,24 @@
+{
+  "coins": [
+    {
+      "id": "COIN::ScholarCoin",
+      "unit": "SCH",
+      "precision": 2
+    },
+    {
+      "id": "COIN::HealthCoin",
+      "unit": "HLH",
+      "precision": 2
+    },
+    {
+      "id": "COIN::EnergyCoin",
+      "unit": "NRG",
+      "precision": 2
+    },
+    {
+      "id": "COIN::CityCoin",
+      "unit": "CIV",
+      "precision": 2
+    }
+  ]
+}

--- a/data/overscale_starter_pack_v1/compare_contrast.csv
+++ b/data/overscale_starter_pack_v1/compare_contrast.csv
@@ -1,0 +1,13 @@
+Sector,EV0L_Practice,Conventional_Practice,Compression_Method,Coins,Vaults,Guards,Key_APIs,KPIs
+Governance,Spiral Council vote spiral,Linear district councils,Golden-angle placement,CityCoin,CityTreasury,"GUARD::CIVIC::CouncilClearance","Participation API; Guard Engine","Resolution turnaround < 48h"
+Treasury,Residual router with reinvest bands,Static annual budgets,Residual partitioning,CityCoin,CityTreasury,"GUARD::TREASURY::DualControl","Vault Router; Audit Log","Residual capture >= 15%"
+Health,PulseBridge consent ledger,Fee-for-service claims,Need-guard triage,HealthCoin,HealthVault,"GUARD::NEED::Income<200%FPL","FHIR/HL7 Bridge; Triage Rules","Preventive coverage reach"
+Education,MetaSchool credential mint,Tuition-locked seats,Merit guard scholarships,ScholarCoin,EducationVault,"GUARD::MERIT::GPA>=3.0","LMS Connector; Placement Oracle","Scholarship activation rate"
+Energy,GridConductor V2G routing,Bulk demand response,Verified meter flows,EnergyCoin,GridVault,"GUARD::ENERGY::MeterVerified","V2G Router; Demand Shaper","Storage participation %"
+Transport,MobilityMesh dispatch mesh,Fixed-route dispatch,Operator guard routing,CityCoin,CityTreasury,"GUARD::TRANSIT::OperatorLicense","Dispatch Optimizer; Telemetry Ingest","On-time arrivals"
+Defense,AlertMesh readiness ledger,Static readiness drills,Readiness guard gating,CityCoin,CityTreasury,"GUARD::DEFENSE::ReadinessLevel3","Incident Chain; Alert Mesh","Response time < 5m"
+Commerce,MirrorBazaar escrow flows,Card processor nets,Voucher compression,CityCoin,CityTreasury,"GUARD::COMMERCE::VendorCredential","Payment Rails; Fulfillment Hooks","Clearance rate > 98%"
+Culture,HeritageGuild recognition ledger,Grant committee cycles,Registry compression,CityCoin,CityTreasury,"GUARD::CULTURE::StewardRegistry","Recognition Ledger; Engagement KPIs","Steward activation"
+Cities,CityHub participatory ledger,Annual capital plans,Participatory compression,CityCoin,CityTreasury,"GUARD::CIVIC::ResidentID","IoT Bus; Work-order Ledger","Work-order closure time"
+Data,LineageGraph stewardship ops,Ad hoc access approvals,Guarded data plane,CityCoin,CityTreasury,"GUARD::DATA::StewardApproval","Access Guards; Lineage Graph","Data issue MTTR"
+Labor,LaborForge unionized matching,Gig platform bidding,Union credential gating,CityCoin,CityTreasury,"GUARD::LABOR::UnionCard","Work-order Ledger; Labor Router","Shift fill rate"

--- a/data/overscale_starter_pack_v1/flows.json
+++ b/data/overscale_starter_pack_v1/flows.json
@@ -1,0 +1,39 @@
+{
+  "flows": [
+    {
+      "id": "FLOW::City\u2192Education::COIN::2025-10-12T00:00Z",
+      "from": "VAULT::CIV::CityTreasury",
+      "to": "VAULT::EDU::EducationVault",
+      "coin": "COIN::ScholarCoin",
+      "amount": 140000.0,
+      "guards": [
+        "GUARD::MERIT::GPA>=3.0",
+        "GUARD::NEED::Income<200%FPL"
+      ],
+      "notes": "Overscale-adjusted scholarship disbursement"
+    },
+    {
+      "id": "FLOW::City\u2192Health::COIN::2025-10-12T00:00Z",
+      "from": "VAULT::CIV::CityTreasury",
+      "to": "VAULT::HLT::HealthVault",
+      "coin": "COIN::HealthCoin",
+      "amount": 210000.0,
+      "guards": [
+        "GUARD::NEED::Income<200%FPL"
+      ],
+      "notes": "Overscale-adjusted preventive care credits"
+    },
+    {
+      "id": "FLOW::City\u2192Energy::COIN::2025-10-12T00:00Z",
+      "from": "VAULT::CIV::CityTreasury",
+      "to": "VAULT::ENG::GridVault",
+      "coin": "COIN::EnergyCoin",
+      "amount": 110833.33,
+      "guards": [
+        "GUARD::ENERGY::MeterVerified"
+      ],
+      "notes": "Overscale-adjusted V2G reserves"
+    }
+  ],
+  "overscale_gamma": 1.1666666666666667
+}

--- a/data/overscale_starter_pack_v1/guards.json
+++ b/data/overscale_starter_pack_v1/guards.json
@@ -1,0 +1,112 @@
+{
+  "guards": [
+    {
+      "id": "GUARD::MERIT::GPA>=3.0",
+      "scope": "access",
+      "rule": "gpa >= 3.0",
+      "expires": "2027-12-31",
+      "proofs": [
+        "doc://transcript"
+      ]
+    },
+    {
+      "id": "GUARD::NEED::Income<200%FPL",
+      "scope": "flows",
+      "rule": "income_pct_fpl < 200",
+      "expires": "2027-12-31",
+      "proofs": [
+        "doc://income_statement"
+      ]
+    },
+    {
+      "id": "GUARD::ENERGY::MeterVerified",
+      "scope": "data",
+      "rule": "meter_status == 'verified'",
+      "expires": "2027-12-31",
+      "proofs": [
+        "doc://utility_meter"
+      ]
+    },
+    {
+      "id": "GUARD::TRANSIT::OperatorLicense",
+      "scope": "access",
+      "rule": "license_status == 'active'",
+      "expires": "2027-12-31",
+      "proofs": [
+        "doc://operator_license"
+      ]
+    },
+    {
+      "id": "GUARD::DEFENSE::ReadinessLevel3",
+      "scope": "flows",
+      "rule": "readiness_level >= 3",
+      "expires": "2027-12-31",
+      "proofs": [
+        "doc://readiness_cert"
+      ]
+    },
+    {
+      "id": "GUARD::COMMERCE::VendorCredential",
+      "scope": "access",
+      "rule": "vendor_status == 'approved'",
+      "expires": "2027-12-31",
+      "proofs": [
+        "doc://vendor_cert"
+      ]
+    },
+    {
+      "id": "GUARD::CULTURE::StewardRegistry",
+      "scope": "data",
+      "rule": "steward_id in registry",
+      "expires": "2027-12-31",
+      "proofs": [
+        "doc://steward_registry"
+      ]
+    },
+    {
+      "id": "GUARD::CIVIC::ResidentID",
+      "scope": "access",
+      "rule": "resident_id_verified == true",
+      "expires": "2027-12-31",
+      "proofs": [
+        "doc://resident_id"
+      ]
+    },
+    {
+      "id": "GUARD::DATA::StewardApproval",
+      "scope": "data",
+      "rule": "data_steward_approved == true",
+      "expires": "2027-12-31",
+      "proofs": [
+        "doc://steward_approval"
+      ]
+    },
+    {
+      "id": "GUARD::LABOR::UnionCard",
+      "scope": "access",
+      "rule": "union_card_valid == true",
+      "expires": "2027-12-31",
+      "proofs": [
+        "doc://union_card"
+      ]
+    },
+    {
+      "id": "GUARD::TREASURY::DualControl",
+      "scope": "flows",
+      "rule": "signatures >= 2",
+      "expires": "2027-12-31",
+      "proofs": [
+        "doc://dual_control"
+      ]
+    },
+    {
+      "id": "GUARD::CIVIC::CouncilClearance",
+      "scope": "access",
+      "rule": "council_clearance == 'green'",
+      "expires": "2027-12-31",
+      "proofs": [
+        "doc://council_clearance"
+      ]
+    }
+  ]
+}

--- a/data/overscale_starter_pack_v1/nodes.json
+++ b/data/overscale_starter_pack_v1/nodes.json
@@ -1,0 +1,292 @@
+{
+  "nodes": [
+    {
+      "id": "EV0L::GOV::SpiralCouncil::v1.0",
+      "sector": "GOV",
+      "type": "city",
+      "loop": 1,
+      "k": 0,
+      "theta_rad": 0.0,
+      "r": 0.0,
+      "pppi": {
+        "status": "active",
+        "rank": 1,
+        "history": []
+      },
+      "guards": [
+        "GUARD::CIVIC::CouncilClearance"
+      ],
+      "vault": "VAULT::CIV::CityTreasury",
+      "coins": [
+        "COIN::CityCoin"
+      ],
+      "bom_refs": [
+        "BOM::GOV::ParticipationAPI"
+      ]
+    },
+    {
+      "id": "EV0L::TRE::VaultRouter::v1.0",
+      "sector": "TRE",
+      "type": "asset",
+      "loop": 2,
+      "k": 1,
+      "theta_rad": 2.3999632297,
+      "r": 1.0,
+      "pppi": {
+        "status": "active",
+        "rank": 1,
+        "history": []
+      },
+      "guards": [
+        "GUARD::TREASURY::DualControl"
+      ],
+      "vault": "VAULT::CIV::CityTreasury",
+      "coins": [
+        "COIN::CityCoin"
+      ],
+      "bom_refs": [
+        "BOM::TRE::VaultRouter"
+      ]
+    },
+    {
+      "id": "EV0L::HLT::PulseBridge::v1.0",
+      "sector": "HLT",
+      "type": "unit",
+      "loop": 3,
+      "k": 2,
+      "theta_rad": 4.7999264595,
+      "r": 1.4142135624,
+      "pppi": {
+        "status": "active",
+        "rank": 1,
+        "history": []
+      },
+      "guards": [
+        "GUARD::NEED::Income<200%FPL"
+      ],
+      "vault": "VAULT::HLT::HealthVault",
+      "coins": [
+        "COIN::HealthCoin"
+      ],
+      "bom_refs": [
+        "BOM::HLT::FHIR_HL7_Bridge"
+      ]
+    },
+    {
+      "id": "EV0L::EDU::MetaSchool::v1.0",
+      "sector": "EDU",
+      "type": "school",
+      "loop": 4,
+      "k": 3,
+      "theta_rad": 7.1998896892,
+      "r": 1.7320508076,
+      "pppi": {
+        "status": "active",
+        "rank": 1,
+        "history": []
+      },
+      "guards": [
+        "GUARD::MERIT::GPA>=3.0"
+      ],
+      "vault": "VAULT::EDU::EducationVault",
+      "coins": [
+        "COIN::ScholarCoin"
+      ],
+      "bom_refs": [
+        "BOM::EDU::LMS_API"
+      ]
+    },
+    {
+      "id": "EV0L::ENG::GridConductor::v1.0",
+      "sector": "ENG",
+      "type": "asset",
+      "loop": 5,
+      "k": 4,
+      "theta_rad": 9.5998529189,
+      "r": 2.0,
+      "pppi": {
+        "status": "active",
+        "rank": 1,
+        "history": []
+      },
+      "guards": [
+        "GUARD::ENERGY::MeterVerified"
+      ],
+      "vault": "VAULT::ENG::GridVault",
+      "coins": [
+        "COIN::EnergyCoin"
+      ],
+      "bom_refs": [
+        "BOM::ENG::V2G_Router"
+      ]
+    },
+    {
+      "id": "EV0L::TRN::MobilityMesh::v1.0",
+      "sector": "TRN",
+      "type": "unit",
+      "loop": 6,
+      "k": 5,
+      "theta_rad": 11.9998161486,
+      "r": 2.2360679775,
+      "pppi": {
+        "status": "active",
+        "rank": 1,
+        "history": []
+      },
+      "guards": [
+        "GUARD::TRANSIT::OperatorLicense"
+      ],
+      "vault": "VAULT::CIV::CityTreasury",
+      "coins": [
+        "COIN::CityCoin"
+      ],
+      "bom_refs": [
+        "BOM::TRN::DispatchOptimizer"
+      ]
+    },
+    {
+      "id": "EV0L::DEF::AlertMesh::v1.0",
+      "sector": "DEF",
+      "type": "asset",
+      "loop": 7,
+      "k": 6,
+      "theta_rad": 14.3997793784,
+      "r": 2.4494897428,
+      "pppi": {
+        "status": "active",
+        "rank": 1,
+        "history": []
+      },
+      "guards": [
+        "GUARD::DEFENSE::ReadinessLevel3"
+      ],
+      "vault": "VAULT::CIV::CityTreasury",
+      "coins": [
+        "COIN::CityCoin"
+      ],
+      "bom_refs": [
+        "BOM::DEF::IncidentChain"
+      ]
+    },
+    {
+      "id": "EV0L::COM::MirrorBazaar::v1.0",
+      "sector": "COM",
+      "type": "asset",
+      "loop": 8,
+      "k": 7,
+      "theta_rad": 16.7997426081,
+      "r": 2.6457513111,
+      "pppi": {
+        "status": "active",
+        "rank": 1,
+        "history": []
+      },
+      "guards": [
+        "GUARD::COMMERCE::VendorCredential"
+      ],
+      "vault": "VAULT::CIV::CityTreasury",
+      "coins": [
+        "COIN::CityCoin"
+      ],
+      "bom_refs": [
+        "BOM::COM::PaymentRails"
+      ]
+    },
+    {
+      "id": "EV0L::CUL::HeritageGuild::v1.0",
+      "sector": "CUL",
+      "type": "blessing",
+      "loop": 1,
+      "k": 8,
+      "theta_rad": 19.1997058378,
+      "r": 2.8284271247,
+      "pppi": {
+        "status": "active",
+        "rank": 1,
+        "history": []
+      },
+      "guards": [
+        "GUARD::CULTURE::StewardRegistry"
+      ],
+      "vault": "VAULT::CIV::CityTreasury",
+      "coins": [
+        "COIN::CityCoin"
+      ],
+      "bom_refs": [
+        "BOM::CUL::RecognitionLedger"
+      ]
+    },
+    {
+      "id": "EV0L::CIV::CityHub::v1.0",
+      "sector": "CIV",
+      "type": "city",
+      "loop": 2,
+      "k": 9,
+      "theta_rad": 21.5996690676,
+      "r": 3.0,
+      "pppi": {
+        "status": "active",
+        "rank": 1,
+        "history": []
+      },
+      "guards": [
+        "GUARD::CIVIC::ResidentID"
+      ],
+      "vault": "VAULT::CIV::CityTreasury",
+      "coins": [
+        "COIN::CityCoin"
+      ],
+      "bom_refs": [
+        "BOM::CIV::IoT_Bus"
+      ]
+    },
+    {
+      "id": "EV0L::DATA::LineageGraph::v1.0",
+      "sector": "DATA",
+      "type": "asset",
+      "loop": 3,
+      "k": 10,
+      "theta_rad": 23.9996322973,
+      "r": 3.1622776602,
+      "pppi": {
+        "status": "active",
+        "rank": 1,
+        "history": []
+      },
+      "guards": [
+        "GUARD::DATA::StewardApproval"
+      ],
+      "vault": "VAULT::CIV::CityTreasury",
+      "coins": [
+        "COIN::CityCoin"
+      ],
+      "bom_refs": [
+        "BOM::DATA::LineageGraph"
+      ]
+    },
+    {
+      "id": "EV0L::LAB::LaborForge::v1.0",
+      "sector": "LAB",
+      "type": "job",
+      "loop": 4,
+      "k": 11,
+      "theta_rad": 26.399595527,
+      "r": 3.3166247904,
+      "pppi": {
+        "status": "active",
+        "rank": 1,
+        "history": []
+      },
+      "guards": [
+        "GUARD::LABOR::UnionCard"
+      ],
+      "vault": "VAULT::CIV::CityTreasury",
+      "coins": [
+        "COIN::CityCoin"
+      ],
+      "bom_refs": [
+        "BOM::LAB::WorkOrderLedger"
+      ]
+    }
+  ]
+}

--- a/data/overscale_starter_pack_v1/overscale_snapshot.yaml
+++ b/data/overscale_starter_pack_v1/overscale_snapshot.yaml
@@ -1,0 +1,15 @@
+snapshot: 2025-10-12T00:00:00Z
+version: EV0L_Scroll_v1.0
+nodes: 12
+loops: 8
+vault_policies:
+  EducationVault: {residual: 0.15, scholarship: 0.15, ops: 0.35, reinvest: 0.35}
+  HealthVault: {residual: 0.12, scholarship: 0.18, ops: 0.35, reinvest: 0.35}
+  GridVault: {residual: 0.10, rebates: 0.20, ops: 0.35, reinvest: 0.35}
+  CityTreasury: {residual: 0.15, microgrants: 0.15, ops: 0.35, reinvest: 0.35}
+guards_active:
+  - GUARD::MERIT::GPA>=3.0
+  - GUARD::NEED::Income<200%FPL
+  - GUARD::ENERGY::MeterVerified
+overscale_gamma: 1.1667
+hash_root: "0x<to-fill-when-minted>"

--- a/data/overscale_starter_pack_v1/vaults.json
+++ b/data/overscale_starter_pack_v1/vaults.json
@@ -1,0 +1,40 @@
+{
+  "vaults": [
+    {
+      "id": "VAULT::EDU::EducationVault",
+      "policy": {
+        "residual": 0.15,
+        "scholarship": 0.15,
+        "ops": 0.35,
+        "reinvest": 0.35
+      }
+    },
+    {
+      "id": "VAULT::HLT::HealthVault",
+      "policy": {
+        "residual": 0.12,
+        "scholarship": 0.18,
+        "ops": 0.35,
+        "reinvest": 0.35
+      }
+    },
+    {
+      "id": "VAULT::ENG::GridVault",
+      "policy": {
+        "residual": 0.1,
+        "rebates": 0.2,
+        "ops": 0.35,
+        "reinvest": 0.35
+      }
+    },
+    {
+      "id": "VAULT::CIV::CityTreasury",
+      "policy": {
+        "residual": 0.15,
+        "microgrants": 0.15,
+        "ops": 0.35,
+        "reinvest": 0.35
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add an Overscale starter pack dataset with canonical node, guard, coin, vault, and flow definitions
- include a compare-and-contrast matrix and minimal audit snapshot to match the Phase 36 kit requirements
- document usage so teams can load the golden-angle placement and treasury policies immediately

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ebfe1cef448324a0f89b82ef53d359