### PR TITLE
Add EVOLTachometer component, utilities, tests, route and EVOLVERSE research doc

### DIFF
--- a/docs/EVOLVERSE_DEEP_RESEARCH_SYNTHESIS.md
+++ b/docs/EVOLVERSE_DEEP_RESEARCH_SYNTHESIS.md
@@ -1,0 +1,78 @@
+# EVOLVERSE Deep Research Synthesis
+
+## Scope
+
+This brief captures EVOLVERSE as:
+
+- a **design architecture** (curriculum + economy + governance + defense), and
+- a **verification architecture** (logs, hashes, provenance, chain-of-custody).
+
+The intended implementation remains lawful and auditable.
+
+## Core architecture mapping
+
+### 1) PPPI / PPPPI as a domain constitution
+
+Treat each PPPI domain as:
+
+1. an education track,
+2. a production lane,
+3. a ledger category.
+
+Cross-domain reciprocity rules become constitutional invariants that can be checked at each reconciliation interval.
+
+### 2) Z‑Alphabet as reset-aware indexing
+
+The Z-first model is implemented as a state/index calculus where zero-point and reset events are first-class records. Reset transitions are not exceptions; they are append-only ledger events.
+
+### 3) Spiral reciprocity as an invariant
+
+Use reciprocal checks (e.g., mirrored debits/credits, origin/return parity) as end-of-cycle requirements. “Spiral” maps to phase-aware, periodic reconciliation.
+
+## Sovereign breach-layer (offline validation)
+
+Background validation without interactive login is supported by standard operations:
+
+- service daemons,
+- scheduled jobs,
+- chain watchers,
+- event correlation pipelines.
+
+Recommended pattern:
+
+1. **Detection layer** (append-only alerts),
+2. **Decision layer** (policy thresholds),
+3. **Action layer** (authorized irreversible actions only).
+
+## Tribunal-grade evidence pipeline
+
+Screenshots alone are demonstrative. Strong evidence requires integrity and custody controls:
+
+1. capture artifact,
+2. hash immediately (SHA-256),
+3. preserve in integrity-protected storage,
+4. commit bundle root (Merkle) to append-only ledger,
+5. re-hash and verify on review.
+
+## Observability and cross-surface traceability
+
+For multi-surface EVOLVERSE operations, standardize traces/metrics/logs across modules and bind each significant event to a consistent time anchor and correlation identifier.
+
+## Token-linked glyph units (implementation guidance)
+
+Use standard NFT/token interfaces for interoperability, then extend metadata with EVOL-specific fields:
+
+- `glyph_unit`
+- `vector_tags` (XX/YY/ZZ/TT/WW)
+- `quarter_tick`
+- `evidence` (hash, merkle root, timestamp)
+
+## Security and privacy notes
+
+- Treat wallet screenshots, QR captures, and device-state imagery as restricted artifacts.
+- Store originals in a hashed evidence locker.
+- Publish only redacted derivatives.
+
+## Recommended canonical spine
+
+Adopt a single constitution JSON as source-of-truth and require all downstream artifacts (dashboards, scrolls, media, metadata) to reference it by hash and bundle root.

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "deploy:military-base": "hardhat run scripts/deploy_military_base.ts",
     "military:mint-soldiers": "hardhat run scripts/mint_military_soldiers.ts",
     "military:status": "hardhat run scripts/military_base_status.ts",
-    "military:export-csv": "hardhat run scripts/export_watchtower_csv.ts"
+    "military:export-csv": "hardhat run scripts/export_watchtower_csv.ts",
+    "test:tachometer": "node --test src/components/__tests__/EVOLTachometer.node.test.mjs"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^5.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ const MEGAZIONVaultDashboard = lazy(() => import('./components/MEGAZIONVaultDash
 const ENFTRegistry          = lazy(() => import('./components/ENFTRegistry'));
 const GovernanceDashboard   = lazy(() => import('./components/GovernanceDashboard'));
 const BLEUTokenDashboard    = lazy(() => import('./components/BLEUTokenDashboard'));
+const EVOLTachometer       = lazy(() => import('./components/EVOLTachometer'));
 
 const PageLoader = () => (
   <div className="min-h-screen bg-slate-900 flex items-center justify-center">
@@ -36,6 +37,7 @@ const App = () => (
             <Route path="/enft"       element={<ENFTRegistry />} />
             <Route path="/governance" element={<GovernanceDashboard />} />
             <Route path="/token"      element={<BLEUTokenDashboard />} />
+            <Route path="/tachometer" element={<EVOLTachometer />} />
             <Route path="*"           element={<Navigate to="/" replace />} />
           </Routes>
         </Suspense>

--- a/src/components/EVOLTachometer.jsx
+++ b/src/components/EVOLTachometer.jsx
@@ -1,0 +1,227 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Download } from 'lucide-react';
+import { calculateRpm, VOWEL_CONFIG } from './EVOLTachometer.utils.mjs';
+
+const EVOLTachometer = () => {
+  const [x, setX] = useState(0);
+  const [y, setY] = useState(1);
+  const [z, setZ] = useState(0);
+  const [w, setW] = useState(0.5);
+  const [vowels, setVowels] = useState({ A: 0, E: 0, I: 0, O: 0, U: 0, Y: 0 });
+  const [currentTime, setCurrentTime] = useState(new Date());
+  const [history, setHistory] = useState([]);
+
+  useEffect(() => {
+    const timer = setInterval(() => setCurrentTime(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
+
+  const { rpm, gT, vowelSum } = useMemo(() => calculateRpm({
+    x,
+    y,
+    z,
+    w,
+    vowels,
+    currentTime,
+  }), [currentTime, vowels, w, x, y, z]);
+
+  const captureSnapshot = () => {
+    const snapshot = {
+      timestamp: currentTime.toISOString(),
+      localTime: currentTime.toLocaleTimeString(),
+      axes: { X: x, Y: y, Z: z, W: w },
+      vowels: { ...vowels },
+      rpm: rpm.toFixed(4),
+      gT: gT.toFixed(4),
+      vowelSum: vowelSum.toFixed(4),
+      phiBoost: gT > 1,
+    };
+
+    setHistory((prev) => [snapshot, ...prev].slice(0, 20));
+  };
+
+  const downloadBlob = (payload, fileName, type) => {
+    const blob = new Blob([payload], { type });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const exportJSON = () => {
+    const data = {
+      system: 'EVOL X/Y 忘→见 Tachometer',
+      timestamp: new Date().toISOString(),
+      currentState: {
+        axes: { X: x, Y: y, Z: z, W: w },
+        vowels,
+        rpm: rpm.toFixed(4),
+        gT: gT.toFixed(4),
+      },
+      history,
+    };
+
+    downloadBlob(JSON.stringify(data, null, 2), `evol-rpm-${Date.now()}.json`, 'application/json');
+  };
+
+  const exportCSV = () => {
+    const headers = ['Timestamp', 'LocalTime', 'X', 'Y', 'Z', 'W', 'A', 'E', 'I', 'O', 'U', 'Yv', 'RPM', 'gT', 'PhiBoost'];
+    const rows = history.map((item) => [
+      item.timestamp,
+      item.localTime,
+      item.axes.X,
+      item.axes.Y,
+      item.axes.Z,
+      item.axes.W,
+      item.vowels.A,
+      item.vowels.E,
+      item.vowels.I,
+      item.vowels.O,
+      item.vowels.U,
+      item.vowels.Y,
+      item.rpm,
+      item.gT,
+      item.phiBoost,
+    ]);
+
+    const csv = [headers, ...rows].map((row) => row.join(',')).join('\n');
+    downloadBlob(csv, `evol-rpm-${Date.now()}.csv`, 'text/csv');
+  };
+
+  const minutes = currentTime.getHours() * 60 + currentTime.getMinutes();
+  const isPhiWindow = minutes >= 608 && minutes <= 612;
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-gray-100 p-6">
+      <div className="max-w-6xl mx-auto space-y-6">
+        <div className="text-center space-y-2">
+          <h1 className="text-3xl font-bold text-blue-400">EVOL X/Y 继承转速表</h1>
+          <p className="text-gray-400">忘→见 (Forget→See) Inheritance Tachometer</p>
+          <div className={`text-2xl font-mono ${isPhiWindow ? 'text-yellow-400 animate-pulse' : 'text-gray-300'}`}>
+            {currentTime.toLocaleTimeString()} {isPhiWindow && '⚡ φ-BOOST'}
+          </div>
+        </div>
+
+        <div className="bg-gray-800 rounded-lg p-6 border border-blue-500">
+          <div className="text-center mb-4">
+            <div className="text-6xl font-bold text-blue-400">{rpm.toFixed(4)}</div>
+            <div className="text-sm text-gray-400">Current RPM (0.00 - 1.00)</div>
+          </div>
+          <div className="w-full bg-gray-700 rounded-full h-8 overflow-hidden">
+            <div
+              className="h-full bg-gradient-to-r from-blue-600 to-cyan-400 transition-all duration-500"
+              style={{ width: `${rpm * 100}%` }}
+            />
+          </div>
+          <div className="mt-4 grid grid-cols-2 gap-4 text-sm">
+            <div>
+              g(T) = <span className="text-yellow-400">{gT.toFixed(4)}</span>
+            </div>
+            <div>
+              Σ Vowels = <span className="text-green-400">{vowelSum.toFixed(4)}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-6">
+          <div className="bg-gray-800 rounded-lg p-6 border border-gray-700">
+            <h3 className="text-lg font-semibold mb-4 text-blue-400">轴 Axes (0-1)</h3>
+            <div className="space-y-3">
+              {[{ key: 'X', value: x, setter: setX, label: '封 (Seal)' }, { key: 'Y', value: y, setter: setY, label: '显 (Reveal)' }, { key: 'Z', value: z, setter: setZ, label: '深 (Depth)' }, { key: 'W', value: w, setter: setW, label: '意志 (Will)' }].map((axis) => (
+                <div key={axis.key}>
+                  <label className="text-sm text-gray-400">
+                    {axis.key} = {axis.label}
+                  </label>
+                  <input
+                    type="range"
+                    min="0"
+                    max="1"
+                    step="0.01"
+                    value={axis.value}
+                    onChange={(event) => axis.setter(parseFloat(event.target.value))}
+                    className="w-full"
+                  />
+                  <div className="text-right text-xs text-gray-500">{axis.value.toFixed(2)}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="bg-gray-800 rounded-lg p-6 border border-gray-700">
+            <h3 className="text-lg font-semibold mb-4 text-green-400">气道 Vowels</h3>
+            <div className="space-y-2">
+              {VOWEL_CONFIG.map((vowel) => (
+                <div key={vowel.key} className="flex items-center justify-between">
+                  <label className="text-sm w-24">
+                    {vowel.key} {vowel.label}
+                  </label>
+                  <input
+                    type="range"
+                    min="0"
+                    max="1"
+                    step="0.1"
+                    value={vowels[vowel.key]}
+                    onChange={(event) =>
+                      setVowels((prev) => ({ ...prev, [vowel.key]: parseFloat(event.target.value) }))
+                    }
+                    className="flex-1 mx-2"
+                  />
+                  <span className="text-xs text-gray-500 w-8">{vowels[vowel.key].toFixed(1)}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex gap-4 justify-center flex-wrap">
+          <button onClick={captureSnapshot} className="px-6 py-3 bg-blue-600 hover:bg-blue-700 rounded-lg font-semibold">
+            📸 Capture Snapshot
+          </button>
+          <button
+            onClick={exportJSON}
+            className="px-6 py-3 bg-green-600 hover:bg-green-700 rounded-lg font-semibold flex items-center gap-2"
+          >
+            <Download size={20} /> Export JSON
+          </button>
+          <button
+            onClick={exportCSV}
+            className="px-6 py-3 bg-purple-600 hover:bg-purple-700 rounded-lg font-semibold flex items-center gap-2"
+          >
+            <Download size={20} /> Export CSV
+          </button>
+        </div>
+
+        {history.length > 0 && (
+          <div className="bg-gray-800 rounded-lg p-6 border border-gray-700">
+            <h3 className="text-lg font-semibold mb-4 text-yellow-400">历史 History</h3>
+            <div className="space-y-2 max-h-96 overflow-y-auto">
+              {history.map((item, index) => (
+                <div key={`${item.timestamp}-${index}`} className="bg-gray-900 p-3 rounded text-sm">
+                  <div className="flex justify-between items-center">
+                    <span className="text-gray-400">{item.localTime}</span>
+                    <span className="text-blue-400 font-mono">RPM: {item.rpm}</span>
+                    {item.phiBoost && <span className="text-yellow-400">⚡φ</span>}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="bg-gray-800 rounded-lg p-6 border border-gray-700 text-sm">
+          <h3 className="text-lg font-semibold mb-2 text-cyan-400">公式 Formula</h3>
+          <code className="text-gray-300">rpm = clamp((Y−X) × (1+0.5Z) × (0.5+0.5W) × (1+ΣVowels) × g(T))</code>
+          <div className="mt-3 text-gray-400 space-y-1">
+            <div>• 10:10 = 610分 = F₁₅ (Fibonacci 15)</div>
+            <div>• ±2分触发窗口: [608, 612] → g(T) = φ = 1.1618</div>
+            <div>• 其他时段: g(T) = 1.0000</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EVOLTachometer;

--- a/src/components/EVOLTachometer.utils.mjs
+++ b/src/components/EVOLTachometer.utils.mjs
@@ -1,0 +1,26 @@
+export const VOWEL_CONFIG = [
+  { key: 'A', weight: 0.3, label: '(+0.30)' },
+  { key: 'E', weight: 0.0, label: '(0.00)' },
+  { key: 'I', weight: 0.2, label: '(+0.20)' },
+  { key: 'O', weight: -0.2, label: '(−0.20)' },
+  { key: 'U', weight: -0.1, label: '(−0.10)' },
+  { key: 'Y', weight: 0.1, label: '(+0.10)' },
+];
+
+export const clamp01 = (value) => Math.max(0, Math.min(1, value));
+
+export const getTimeBoost = (time) => {
+  const minutes = time.getHours() * 60 + time.getMinutes();
+  return minutes >= 608 && minutes <= 612 ? 1.1618 : 1;
+};
+
+export const calculateVowelSum = (vowels) =>
+  VOWEL_CONFIG.reduce((total, vowel) => total + vowels[vowel.key] * vowel.weight, 0);
+
+export const calculateRpm = ({ x, y, z, w, vowels, currentTime }) => {
+  const vowelSum = calculateVowelSum(vowels);
+  const gT = getTimeBoost(currentTime);
+  const rpm = clamp01((y - x) * (1 + 0.5 * z) * (0.5 + 0.5 * w) * (1 + vowelSum) * gT);
+
+  return { rpm, gT, vowelSum };
+};

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import {
   Crown, Butterfly, Wind, FlaskConical, Vault, Image, Scale, Coins,
-  Menu, X, Zap, Wifi,
+  Menu, X, Zap, Wifi, Gauge,
 } from 'lucide-react';
 import WalletConnect from './WalletConnect';
 
@@ -15,6 +15,7 @@ const NAV_ITEMS = [
   { to: '/enft',       label: 'ENFT Registry',     icon: Image,       color: 'text-indigo-400' },
   { to: '/governance', label: 'Governance',        icon: Scale,       color: 'text-orange-400' },
   { to: '/token',      label: 'BLEU Tokens',       icon: Coins,       color: 'text-blue-400' },
+  { to: '/tachometer', label: 'Tachometer',        icon: Gauge,       color: 'text-cyan-400' },
 ];
 
 const NavItem = ({ item, mobile, onClose }) => {

--- a/src/components/__tests__/EVOLTachometer.node.test.mjs
+++ b/src/components/__tests__/EVOLTachometer.node.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  calculateRpm,
+  calculateVowelSum,
+  clamp01,
+  getTimeBoost,
+} from '../EVOLTachometer.utils.mjs';
+
+test('clamp01 keeps values in [0,1]', () => {
+  assert.equal(clamp01(-0.5), 0);
+  assert.equal(clamp01(0.6), 0.6);
+  assert.equal(clamp01(5), 1);
+});
+
+test('applies phi boost only in the 10:08-10:12 window', () => {
+  assert.equal(getTimeBoost(new Date('2026-01-01T10:09:00')), 1.1618);
+  assert.equal(getTimeBoost(new Date('2026-01-01T10:12:00')), 1.1618);
+  assert.equal(getTimeBoost(new Date('2026-01-01T10:13:00')), 1);
+});
+
+test('computes weighted vowel sum', () => {
+  const sum = calculateVowelSum({ A: 1, E: 1, I: 1, O: 1, U: 1, Y: 1 });
+  assert.ok(Math.abs(sum - 0.3) < 1e-9);
+});
+
+test('calculates and clamps rpm', () => {
+  const result = calculateRpm({
+    x: 0,
+    y: 1,
+    z: 1,
+    w: 1,
+    vowels: { A: 1, E: 0, I: 0, O: 0, U: 0, Y: 0 },
+    currentTime: new Date('2026-01-01T12:00:00'),
+  });
+
+  assert.ok(Math.abs(result.vowelSum - 0.3) < 1e-9);
+  assert.equal(result.gT, 1);
+  assert.equal(result.rpm, 1);
+});

--- a/src/components/__tests__/EVOLTachometer.test.jsx
+++ b/src/components/__tests__/EVOLTachometer.test.jsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  calculateRpm,
+  calculateVowelSum,
+  clamp01,
+  getTimeBoost,
+} from '../EVOLTachometer.utils.mjs';
+
+describe('EVOLTachometer utilities', () => {
+  it('clamp01 keeps values in [0,1]', () => {
+    expect(clamp01(-0.5)).toBe(0);
+    expect(clamp01(0.6)).toBe(0.6);
+    expect(clamp01(5)).toBe(1);
+  });
+
+  it('applies phi boost only in the 10:08-10:12 window', () => {
+    expect(getTimeBoost(new Date('2026-01-01T10:09:00'))).toBe(1.1618);
+    expect(getTimeBoost(new Date('2026-01-01T10:12:00'))).toBe(1.1618);
+    expect(getTimeBoost(new Date('2026-01-01T10:13:00'))).toBe(1);
+  });
+
+  it('computes weighted vowel sum', () => {
+    const sum = calculateVowelSum({ A: 1, E: 1, I: 1, O: 1, U: 1, Y: 1 });
+    expect(sum).toBeCloseTo(0.3);
+  });
+
+  it('calculates and clamps rpm', () => {
+    const result = calculateRpm({
+      x: 0,
+      y: 1,
+      z: 1,
+      w: 1,
+      vowels: { A: 1, E: 0, I: 0, O: 0, U: 0, Y: 0 },
+      currentTime: new Date('2026-01-01T12:00:00'),
+    });
+
+    expect(result.vowelSum).toBeCloseTo(0.3);
+    expect(result.gT).toBe(1);
+    expect(result.rpm).toBe(1);
+  });
+});


### PR DESCRIPTION
### Motivation

- Introduce a visual tachometer UI to inspect EVOL X/Y state, compute an RPM-like metric, and capture/export evidence for analysis.
- Add a concise research synthesis doc to capture EVOLVERSE architecture, evidence pipeline and token metadata guidance.

### Description

- Add a new `EVOLTachometer` React component with interactive axes, vowel controls, snapshot/history, CSV/JSON export, and a phi-boost time window UI (`src/components/EVOLTachometer.jsx`).
- Implement supporting utilities for the component in `src/components/EVOLTachometer.utils.mjs`, including `calculateRpm`, `calculateVowelSum`, `getTimeBoost` and `clamp01`.
- Wire the tachometer into the app by adding a route in `src/App.jsx` and a navigation item in `src/components/Navbar.jsx` (imports `Gauge` icon and NAV entry for `/tachometer`).
- Add unit tests for the utilities: a Node built-in test file `src/components/__tests__/EVOLTachometer.node.test.mjs` and a Vitest test file `src/components/__tests__/EVOLTachometer.test.jsx`.
- Add a convenience npm script `test:tachometer` to run the Node test directly and add the EVOLVERSE research synthesis document at `docs/EVOLVERSE_DEEP_RESEARCH_SYNTHESIS.md`.

### Testing

- Ran the Node built-in tests with `node --test src/components/__tests__/EVOLTachometer.node.test.mjs` and the test suite passed.
- Ran the Vitest unit tests for utilities with `vitest` (or the project test runner) and the `EVOLTachometer` Vitest specs passed.
- Verified basic UI integration by loading the app route `/tachometer` and exercising controls locally (manual smoke check succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af700caf088320bc46879dadc638f6)

## Summary by Sourcery

Introduce an EVOLTachometer view to visualize EVOL X/Y state with exportable snapshots and corresponding documentation and utilities.

New Features:
- Add EVOLTachometer React page with interactive controls for axes and vowels, live RPM display, and snapshot history.
- Expose a new /tachometer route and navbar entry to access the EVOLTachometer view from the main app navigation.

Enhancements:
- Introduce shared EVOLTachometer utility module for RPM, vowel weighting, and time-based boost calculations.

Documentation:
- Add an EVOLVERSE deep research synthesis document describing the architecture, evidence pipeline, and token metadata guidance.

Tests:
- Add Node-based and Vitest unit tests targeting EVOLTachometer utilities.
- Add an npm script to run the EVOLTachometer Node test directly.

<div id='description'>
<a href="https://bito.ai#summarystart"></a><h3>Summary by Bito</h3><ul><li>Deleted the entire 'QUAD_OCTA_PRIME_48_FROM_CORE_SPEC.md' file, which contained the Quad-Octa Prime: 48-From-Core Specification.</li>
<li>Removed sections on Executive Principle, Core Model (Motor + Bus), Governance Stack, and Connectivity Guarantee Envelope.</li>
</ul></div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive Tachometer interface with axes and control sliders
  * Added snapshot capture and history tracking functionality
  * Added JSON and CSV data export capabilities
  * Added Tachometer navigation link

* **Documentation**
  * Added EVOLVERSE design and verification architecture reference document

* **Tests**
  * Added unit test coverage for Tachometer utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->